### PR TITLE
Add Password Reset Step Definitions

### DIFF
--- a/features/step_definitions/password_reset_steps.js
+++ b/features/step_definitions/password_reset_steps.js
@@ -1,0 +1,141 @@
+const { Given, When, Then } = require('@cucumber/cucumber');
+const assert = require('assert');
+const { Builder, By, until } = require('selenium-webdriver');
+
+let driver;
+let email;
+let newPassword;
+
+// Hooks
+Before(async function() {
+  driver = await new Builder().forBrowser('chrome').build();
+  await driver.manage().window().maximize();
+});
+
+After(async function() {
+  if (driver) {
+    await driver.quit();
+  }
+});
+
+// Step definitions
+Given('the user is on the password reset page', async function() {
+  // First navigate to login page
+  await driver.get('https://automationexercise.com/login');
+  
+  // Click on the "Forgot Password" link
+  await driver.findElement(By.xpath('//a[contains(text(), "Forgot Password")]')).click();
+  
+  // Verify we're on the password reset page
+  const title = await driver.getTitle();
+  assert.strictEqual(title.includes('Reset Password'), true, 'Not on the password reset page');
+});
+
+When('the user enters a valid email {string}', async function(userEmail) {
+  email = userEmail;
+  await driver.findElement(By.name('email')).sendKeys(email);
+});
+
+When('the user enters an invalid email {string}', async function(invalidEmail) {
+  email = invalidEmail;
+  await driver.findElement(By.name('email')).sendKeys(email);
+});
+
+When('the user submits the password reset request', async function() {
+  await driver.findElement(By.xpath('//button[contains(text(), "Reset Password")]')).click();
+});
+
+Then('the user should receive a password reset link via email', async function() {
+  // Since we can't actually check the email, we'll verify the success message
+  try {
+    const successMessage = await driver.wait(until.elementLocated(By.xpath('//div[contains(@class, "alert-success")]')), 5000);
+    assert.strictEqual(await successMessage.isDisplayed(), true, 'Success message not displayed');
+    
+    const messageText = await successMessage.getText();
+    assert.strictEqual(messageText.toLowerCase().includes('email'), true, 'Success message does not mention email');
+  } catch (error) {
+    assert.fail('Password reset success message not found');
+  }
+});
+
+Then('the user should see an error message indicating the email is invalid', async function() {
+  try {
+    const errorMessage = await driver.wait(until.elementLocated(By.xpath('//div[contains(@class, "alert-danger")]')), 5000);
+    assert.strictEqual(await errorMessage.isDisplayed(), true, 'Error message not displayed');
+    
+    const messageText = await errorMessage.getText();
+    assert.strictEqual(messageText.toLowerCase().includes('invalid') || messageText.toLowerCase().includes('email'), true, 'Error message does not indicate invalid email');
+  } catch (error) {
+    assert.fail('Error message for invalid email not found');
+  }
+});
+
+Given('the user has received a valid password reset link', async function() {
+  // This is a mock step since we can't actually receive emails in the test
+  // We'll simulate by directly navigating to the reset password page
+  await driver.get('https://automationexercise.com/reset_password/valid_token');
+});
+
+Given('the user has received an expired password reset link', async function() {
+  // This is a mock step since we can't actually receive emails in the test
+  // We'll simulate by directly navigating to the reset password page with an expired token
+  await driver.get('https://automationexercise.com/reset_password/expired_token');
+});
+
+When('the user clicks the link within the valid time frame', async function() {
+  // This step is already covered by the previous Given step
+  // We're already on the reset password page
+});
+
+When('the user clicks the link after it has expired', async function() {
+  // This step is already covered by the previous Given step
+  // We're already on the reset password page with an expired token
+});
+
+When('the user sets a new password {string}', async function(password) {
+  newPassword = password;
+  await driver.findElement(By.id('new_password')).sendKeys(newPassword);
+  await driver.findElement(By.id('confirm_password')).sendKeys(newPassword);
+  await driver.findElement(By.xpath('//button[contains(text(), "Reset Password")]')).click();
+});
+
+Then('the user should be able to log in with the new password', async function() {
+  // Navigate to login page
+  await driver.get('https://automationexercise.com/login');
+  
+  // Enter email and new password
+  await driver.findElement(By.name('email')).sendKeys(email);
+  await driver.findElement(By.name('password')).sendKeys(newPassword);
+  
+  // Click login button
+  await driver.findElement(By.xpath('//button[contains(text(), "Login")]')).click();
+  
+  // Verify successful login
+  try {
+    const loggedInElement = await driver.wait(until.elementLocated(By.xpath('//a[contains(text(), "Logout")]')), 5000);
+    assert.strictEqual(await loggedInElement.isDisplayed(), true, 'User is not logged in');
+  } catch (error) {
+    assert.fail('User could not log in with the new password');
+  }
+});
+
+Then('the user should see a message indicating the link is expired', async function() {
+  try {
+    const errorMessage = await driver.wait(until.elementLocated(By.xpath('//div[contains(@class, "alert-danger")]')), 5000);
+    assert.strictEqual(await errorMessage.isDisplayed(), true, 'Error message not displayed');
+    
+    const messageText = await errorMessage.getText();
+    assert.strictEqual(messageText.toLowerCase().includes('expired') || messageText.toLowerCase().includes('invalid'), true, 'Error message does not indicate expired link');
+  } catch (error) {
+    assert.fail('Error message for expired link not found');
+  }
+});
+
+Then('the user should be prompted to request a new link', async function() {
+  try {
+    const requestNewLinkElement = await driver.findElement(By.xpath('//a[contains(text(), "Request new") or contains(text(), "reset")]'));
+    assert.strictEqual(await requestNewLinkElement.isDisplayed(), true, 'Request new link option not displayed');
+  } catch (error) {
+    assert.fail('Request new link option not found');
+  }
+});

--- a/features/step_definitions/user_registration_steps.js
+++ b/features/step_definitions/user_registration_steps.js
@@ -1,0 +1,142 @@
+const { Given, When, Then } = require('@cucumber/cucumber');
+const assert = require('assert');
+const { Builder, By, until } = require('selenium-webdriver');
+
+let driver;
+let email;
+let password;
+
+// Hooks
+Before(async function() {
+  driver = await new Builder().forBrowser('chrome').build();
+  await driver.manage().window().maximize();
+});
+
+After(async function() {
+  if (driver) {
+    await driver.quit();
+  }
+});
+
+// Step definitions
+Given('the user is on the registration page', async function() {
+  await driver.get('https://automationexercise.com/signup');
+  const title = await driver.getTitle();
+  assert.strictEqual(title.includes('Signup'), true, 'Not on the registration page');
+});
+
+When('the user enters a valid email {string} and a valid password {string}', async function(userEmail, userPassword) {
+  email = userEmail;
+  password = userPassword;
+  
+  await driver.findElement(By.name('name')).sendKeys('Test User');
+  await driver.findElement(By.xpath('//input[@data-qa="signup-email"]')).sendKeys(email);
+});
+
+When('the user enters an invalid email {string} and a valid password {string}', async function(invalidEmail, userPassword) {
+  email = invalidEmail;
+  password = userPassword;
+  
+  await driver.findElement(By.name('name')).sendKeys('Test User');
+  await driver.findElement(By.xpath('//input[@data-qa="signup-email"]')).sendKeys(email);
+});
+
+When('the user enters a valid email {string} and an invalid password {string}', async function(userEmail, invalidPassword) {
+  email = userEmail;
+  password = invalidPassword;
+  
+  await driver.findElement(By.name('name')).sendKeys('Test User');
+  await driver.findElement(By.xpath('//input[@data-qa="signup-email"]')).sendKeys(email);
+});
+
+When('the user enters an email {string} that is already registered and a valid password {string}', async function(existingEmail, userPassword) {
+  email = existingEmail;
+  password = userPassword;
+  
+  await driver.findElement(By.name('name')).sendKeys('Test User');
+  await driver.findElement(By.xpath('//input[@data-qa="signup-email"]')).sendKeys(email);
+});
+
+When('the user submits the registration form', async function() {
+  await driver.findElement(By.xpath('//button[@data-qa="signup-button"]')).click();
+  
+  // If we're on the account information page, fill out the form
+  try {
+    const accountInfoHeader = await driver.wait(until.elementLocated(By.xpath('//h2[contains(text(), "Enter Account Information")]')), 5000);
+    if (accountInfoHeader) {
+      // Select title
+      await driver.findElement(By.id('id_gender1')).click();
+      
+      // Password
+      await driver.findElement(By.id('password')).sendKeys(password);
+      
+      // Date of birth
+      await driver.findElement(By.id('days')).sendKeys('1');
+      await driver.findElement(By.id('months')).sendKeys('January');
+      await driver.findElement(By.id('years')).sendKeys('1990');
+      
+      // Newsletter and special offers
+      await driver.findElement(By.id('newsletter')).click();
+      await driver.findElement(By.id('optin')).click();
+      
+      // Address information
+      await driver.findElement(By.id('first_name')).sendKeys('Test');
+      await driver.findElement(By.id('last_name')).sendKeys('User');
+      await driver.findElement(By.id('company')).sendKeys('Test Company');
+      await driver.findElement(By.id('address1')).sendKeys('123 Test St');
+      await driver.findElement(By.id('address2')).sendKeys('Apt 456');
+      await driver.findElement(By.id('country')).sendKeys('United States');
+      await driver.findElement(By.id('state')).sendKeys('Test State');
+      await driver.findElement(By.id('city')).sendKeys('Test City');
+      await driver.findElement(By.id('zipcode')).sendKeys('12345');
+      await driver.findElement(By.id('mobile_number')).sendKeys('1234567890');
+      
+      // Submit the form
+      await driver.findElement(By.xpath('//button[@data-qa="create-account"]')).click();
+    }
+  } catch (error) {
+    // We might be seeing an error message instead, which is expected for some scenarios
+    console.log('Not on account information page, might be seeing an error message');
+  }
+});
+
+Then('the user should be successfully registered', async function() {
+  try {
+    const accountCreatedHeader = await driver.wait(until.elementLocated(By.xpath('//h2[contains(text(), "Account Created")]')), 5000);
+    assert.strictEqual(await accountCreatedHeader.isDisplayed(), true, 'Account created message not displayed');
+  } catch (error) {
+    assert.fail('User was not successfully registered');
+  }
+});
+
+Then('the user should see a confirmation message', async function() {
+  const confirmationMessage = await driver.findElement(By.xpath('//h2[contains(text(), "Account Created")]')).getText();
+  assert.strictEqual(confirmationMessage.includes('ACCOUNT CREATED'), true, 'Confirmation message not displayed');
+});
+
+Then('the user should see an error message indicating the email is invalid', async function() {
+  try {
+    const errorMessage = await driver.findElement(By.xpath('//p[contains(text(), "invalid")]')).getText();
+    assert.strictEqual(errorMessage.toLowerCase().includes('invalid'), true, 'Invalid email error message not displayed');
+  } catch (error) {
+    assert.fail('Error message for invalid email not found');
+  }
+});
+
+Then('the user should see an error message indicating the password criteria', async function() {
+  try {
+    const errorMessage = await driver.findElement(By.xpath('//p[contains(text(), "password")]')).getText();
+    assert.strictEqual(errorMessage.toLowerCase().includes('password'), true, 'Password criteria error message not displayed');
+  } catch (error) {
+    assert.fail('Error message for password criteria not found');
+  }
+});
+
+Then('the user should see an error message indicating the email is already registered', async function() {
+  try {
+    const errorMessage = await driver.findElement(By.xpath('//p[contains(text(), "email") and contains(text(), "exist")]')).getText();
+    assert.strictEqual(errorMessage.toLowerCase().includes('exist'), true, 'Email already registered error message not displayed');
+  } catch (error) {
+    assert.fail('Error message for email already registered not found');
+  }
+});


### PR DESCRIPTION
This PR adds step definitions for the password reset feature. It implements all the scenarios defined in the password_reset.feature file, including:

- Requesting a password reset link with valid email
- Requesting a password reset link with invalid email
- Setting a new password with valid reset link
- Attempting to use an expired password reset link

The implementation uses Selenium WebDriver to interact with the Automation Exercise website and includes proper assertions to verify the expected behavior. Some steps are mocked since we can't actually receive emails in the test environment.