### PR TITLE
docs: add README for com.automationexercise package and fix cucumber.json paths

### DIFF
--- a/com.automationexercise/README.md
+++ b/com.automationexercise/README.md
@@ -1,0 +1,13 @@
+AutomationExercise E2E Tests
+
+This package contains Playwright + Cucumber BDD tests against https://automationexercise.com/
+
+Structure:
+- features/: Gherkin feature files
+- steps/: Step definitions implemented with Playwright
+- support/: World, hooks and configuration
+
+Usage:
+- npm install
+- npx cucumber-js --config com.automationexercise/cucumber.json
+

--- a/com.automationexercise/README.md
+++ b/com.automationexercise/README.md
@@ -8,6 +8,7 @@ Structure:
 - support/: World, hooks and configuration
 
 Usage:
+- cd com.automationexercise
 - npm install
-- npx cucumber-js --config com.automationexercise/cucumber.json
+- npx cucumber-js --config cucumber.json
 

--- a/com.automationexercise/cucumber.json
+++ b/com.automationexercise/cucumber.json
@@ -1,43 +1,22 @@
 {
-
-    "default": {
-
-        "paths": [
-
-            "features/"
-
-        ],
-
-        "require": [
-
-            "steps/*.js"
-
-        ],
-
-        "formatOptions": {
-
-            "snippetInterface": "async-await"
-
-        },
-
-        "format": [
-
-            [
-
-                "html",
-
-                "cucumber-report.html"
-
-            ],
-
-            "summary",
-
-            "progress-bar",
-
-            "json:./cucumber-report.json"
-
-        ]
-
-    }
-
+  "default": {
+    "paths": [
+      "com.automationexercise/features"
+    ],
+    "require": [
+      "com.automationexercise/steps/*.js"
+    ],
+    "formatOptions": {
+      "snippetInterface": "async-await"
+    },
+    "format": [
+      [
+        "html",
+        "com.automationexercise/cucumber-report.html"
+      ],
+      "summary",
+      "progress-bar",
+      "json:./com.automationexercise/cucumber-report.json"
+    ]
+  }
 }


### PR DESCRIPTION
- Added README with usage instructions for the com.automationexercise test package
- Updated cucumber.json to point to consolidated features and steps paths

This improves developer onboarding and ensures cucumber runs from package root.
